### PR TITLE
Retrieve correct `id` value

### DIFF
--- a/lib/passport-wordpress/strategy.js
+++ b/lib/passport-wordpress/strategy.js
@@ -40,11 +40,11 @@ var util = require('util')
  * @api public
  */
 function Strategy(options, verify) {
-  options = options || {}; 
+  options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://public-api.wordpress.com/oauth2/authorize';
   options.tokenURL = options.tokenURL || 'https://public-api.wordpress.com/oauth2/token';
   this.profileUrl = options.profileUrl || "https://public-api.wordpress.com/rest/v1/me";
-  
+
   OAuth2Strategy.call(this, options, verify);
   this.name = 'wordpress';
 }
@@ -69,17 +69,17 @@ util.inherits(Strategy, OAuth2Strategy);
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
   this._oauth2.useAuthorizationHeaderforGET(true);
-    
-  this._oauth2.get(this.profileUrl, accessToken, function (err, body, res) {      
+
+  this._oauth2.get(this.profileUrl, accessToken, function (err, body, res) {
     if (err) { return done(err); }
 
     try {
       var json = JSON.parse(body);
-      
+
       var profile = { provider: 'Wordpress' };
-      profile.id = json.id;
+      profile.id = json.ID || json.id;
       profile.displayName = json.username;
-      
+
       profile._raw = body;
       profile._json = json;
       done(null, profile);


### PR DESCRIPTION
Cause we have 'ID' key in response:

```
_raw: '{"ID":47708186,"display_name":"keitoaino","username":"keitoaino","email":"keitoaino@gmail.com","primary_blog":104568540,"primary_blog_url":"http:\\/\\/keitoainoblog.wordpress.com","language":"en","token_site_id":104568540,"token_scope":[""],"avatar_URL":"https:\\/\\/0.gravatar.com\\/avatar\\/98601b3f28cf3b878bc771bcf3a43dec?s=96&d=identicon&r=G","profile_URL":"http:\\/\\/en.gravatar.com\\/keitoaino","verified":true,"email_verified":true,"date":"2013-03-23T14:42:53+00:00","site_count":1,"visible_site_count":1,"has_unseen_notes":false,"newest_note_type":"","phone_account":false,"meta":{"links":{"self":"https:\\/\\/public-api.wordpress.com\\/rest\\/v1\\/me","help":"https:\\/\\/public-api.wordpress.com\\/rest\\/v1\\/me\\/help","site":"https:\\/\\/public-api.wordpress.com\\/rest\\/v1\\/sites\\/104568540","flags":"https:\\/\\/public-api.wordpress.com\\/rest\\/v1\\/me\\/flags"}},"is_valid_google_apps_country":true}'
```