### PR TITLE
passport-oauth@1.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "./lib/passport-wordpress",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "~0.1.1"
+    "passport-oauth": "1.x.x"
   },
   "engines": {
     "node": ">= 0.4.0"


### PR DESCRIPTION
update to the latest version of `passport-oauth` (there are no breaking changes)
